### PR TITLE
Fix: Do not skip top contributor in the list.

### DIFF
--- a/javascripts/top-contributors-sidebar/connectors/before-topic-list-body/top-contributors-sidebar.js
+++ b/javascripts/top-contributors-sidebar/connectors/before-topic-list-body/top-contributors-sidebar.js
@@ -23,7 +23,7 @@ export default {
               .then(response => response.json())
               .then(data => {
                 component.set("hideSidebar", false);
-                this.set("topContributors", data.directory_items.slice(1, 6));
+                this.set("topContributors", data.directory_items.slice(0, 5));
               });
             } else {
               component.set("isDiscoveryList", false);


### PR DESCRIPTION
The JS slice function is inclusive of the starting point. The component currently appears to be skipping the first user from the list of top contributors. 