### PR TITLE
FIX: fix broken view when using bulk actions

### DIFF
--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -1,11 +1,5 @@
-.topic-list.with-sidebar {
-  > div {
-    display: none;
-  }
-}
-
 @media screen and (min-width: 767px) {
-  #list-area > .contents > .topic-list.with-sidebar {
+  #list-area > .contents > .topic-list {
     display: grid;
     grid-column-gap: 2%;
     align-items: start;


### PR DESCRIPTION
The top contributors sidebar view was broken when the bulk action option is selected.

Meta ref: https://meta.discourse.org/t/top-contributors-sidebar-persistently-stretches-across-the-screen-when-using-bulk-actions/287427

Before:

<img width="1122" alt="Screenshot 2023-12-05 at 4 02 02 PM" src="https://github.com/discourse/discourse-top-contributors-sidebar/assets/11170663/e278eacb-3b35-4c59-82da-e3a2575b7471">

After:

<img width="1154" alt="Screenshot 2023-12-05 at 4 03 34 PM" src="https://github.com/discourse/discourse-top-contributors-sidebar/assets/11170663/cce711bc-4ecb-4162-ae2e-a09f9a479a16">
