### PR TITLE
FIX: check if component is destroyed, adjust width

### DIFF
--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -26,7 +26,7 @@
       grid-area: sidebar;
       border: 1px solid var(--primary-low);
       padding: 1em;
-      width: 100%;
+      width: auto;
       border-radius: 6px;
       box-shadow: 0 0 6px -2px rgba(var(--primary-rgb), 0.25);
 

--- a/javascripts/top-contributors-sidebar/connectors/before-topic-list-body/top-contributors-sidebar.js
+++ b/javascripts/top-contributors-sidebar/connectors/before-topic-list-body/top-contributors-sidebar.js
@@ -39,6 +39,10 @@ export default {
 
     withPluginApi("0.11", (api) => {
       api.onPageChange(() => {
+        if (component.isDestroying || component.isDestroyed) {
+          return;
+        }
+
         component.set("isDiscoveryList", !!this.discoveryList);
         fetchDirectoryItems(settings, component);
       });


### PR DESCRIPTION
This component could use a refactor, but for now: 

* Resolves `Error: Assertion Failed: calling set on destroyed object`

* Fixes an overflow issue... 

  Before:
   ![image](https://github.com/user-attachments/assets/94950671-b56d-4b38-92b1-671e1cef39be)

  After:
   ![image](https://github.com/user-attachments/assets/0f3bb2e6-cf6d-4740-9228-3245ea89b488)
